### PR TITLE
Spark version update/logging class changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: common accrdd nam
 common: 
 	make -C ./common
 
-accrdd:
+accrdd: common
 	cd accrdd; mvn package; mvn install
 
 nam: common

--- a/accrdd/pom.xml
+++ b/accrdd/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.version.tools}</artifactId>
-      <version>1.5.1</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/accrdd/src/main/java/org/apache/spark/blaze/DataTransmitter.java
+++ b/accrdd/src/main/java/org/apache/spark/blaze/DataTransmitter.java
@@ -1,4 +1,3 @@
-
 package org.apache.spark.blaze;
 
 import java.lang.InterruptedException;

--- a/accrdd/src/main/scala/org/apache/spark/blaze/AccMapPartitionsRDD.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/AccMapPartitionsRDD.scala
@@ -15,7 +15,7 @@ import org.apache.spark.rdd._
 import org.apache.spark.storage._
 import org.apache.spark.scheduler._
 import org.apache.spark.util.random.RandomSampler
-
+import org.apache.spark.internal.Logging
 /**
   * A RDD that uses accelerator to accelerate the computation. The behavior of AccMapPartitionsRDD is 
   * similar to Spark MapPartitionsRDD which performs the computation for a whole partition at a

--- a/accrdd/src/main/scala/org/apache/spark/blaze/AccRDD.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/AccRDD.scala
@@ -15,6 +15,7 @@ import org.apache.spark.rdd._
 import org.apache.spark.storage._
 import org.apache.spark.scheduler._
 import org.apache.spark.util.random._
+import org.apache.spark.internal.Logging;
 
 /**
   * A RDD that uses accelerator to accelerate the computation. The behavior of AccRDD is 

--- a/accrdd/src/main/scala/org/apache/spark/blaze/AccRDD.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/AccRDD.scala
@@ -15,7 +15,7 @@ import org.apache.spark.rdd._
 import org.apache.spark.storage._
 import org.apache.spark.scheduler._
 import org.apache.spark.util.random._
-import org.apache.spark.internal.Logging;
+import org.apache.spark.internal.Logging
 
 /**
   * A RDD that uses accelerator to accelerate the computation. The behavior of AccRDD is 

--- a/accrdd/src/main/scala/org/apache/spark/blaze/BlazeBroadcast.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/BlazeBroadcast.scala
@@ -4,7 +4,7 @@ import java.io._
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.SparkException
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
 import scala.reflect.ClassTag

--- a/accrdd/src/main/scala/org/apache/spark/blaze/BlazeRuntime.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/BlazeRuntime.scala
@@ -4,14 +4,13 @@ import java.io._
 import scala.util.matching.Regex
 import scala.reflect.ClassTag
 
-import org.apache.spark.internal.Logging;
-
 import org.apache.spark._
 import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.rdd._
 import org.apache.spark.storage._
 import org.apache.spark.scheduler._
 import org.apache.spark.broadcast._
+import org.apache.spark.internal.Logging
 
 /**
   * The entry point of Blaze runtime system. BlazeRuntime is mainly used for 

--- a/accrdd/src/main/scala/org/apache/spark/blaze/BlazeRuntime.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/BlazeRuntime.scala
@@ -4,6 +4,8 @@ import java.io._
 import scala.util.matching.Regex
 import scala.reflect.ClassTag
 
+import org.apache.spark.internal.Logging;
+
 import org.apache.spark._
 import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.rdd._
@@ -19,6 +21,7 @@ import org.apache.spark.broadcast._
   * @param sc Spark context.
   */
 class BlazeRuntime(sc: SparkContext) extends Logging {
+  // get Logger object
 
   // The application signature generated based on Spark application ID.
   val appSignature: String = sc.applicationId
@@ -47,7 +50,7 @@ class BlazeRuntime(sc: SparkContext) extends Logging {
         .distinct
         .map(w => (w, accPort))
 
-      logInfo("Releasing broadcast blocks from workers (" + WorkerList.length + "): " + 
+      logInfo("Releasing broadcast blocks from workers (" + WorkerList.length + "): " +
         WorkerList.map(w => w._1).mkString(", "))
 
       val msg = DataTransmitter.buildMessage(appSignature, AccMessage.MsgType.ACCTERM)

--- a/accrdd/src/main/scala/org/apache/spark/blaze/BlockInfo.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/BlockInfo.scala
@@ -2,7 +2,7 @@ package org.apache.spark.blaze
 
 import java.io._
 
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
 import scala.reflect.ClassTag

--- a/accrdd/src/main/scala/org/apache/spark/blaze/ShellRDD.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/ShellRDD.scala
@@ -64,9 +64,9 @@ class ShellRDD[T: ClassTag](
       thisSampler = new BernoulliSampler[Int](fraction)
     thisSampler.setSeed(seed)
 
-    if (seed == 904401792) { // Test mode
-      thisSampler = new TestSampler[Int]
-    }
+    //if (seed == 904401792) { // Test mode
+    //  thisSampler = new TestSampler[Int]
+    //}
 
     new ShellRDD(appId, this, port, thisSampler)
   }

--- a/accrdd/src/main/scala/org/apache/spark/blaze/TestSampler.scala
+++ b/accrdd/src/main/scala/org/apache/spark/blaze/TestSampler.scala
@@ -9,7 +9,7 @@ import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.rdd._
 import org.apache.spark.util.random._
 
-class TestSampler[T] extends RandomSampler[T, T] {
+abstract class TestSampler[T] extends RandomSampler[T, T] {
 
   override def setSeed(r: Long) = {}
 
@@ -27,5 +27,5 @@ class TestSampler[T] extends RandomSampler[T, T] {
     out.iterator
   }
 
-  override def clone = new TestSampler[T]
+  //override def clone = new TestSampler[T]
 }

--- a/manager/src/main.cpp
+++ b/manager/src/main.cpp
@@ -15,6 +15,7 @@
 
 #define LOG_HEADER "main"
 #include <glog/logging.h>
+#include <gflags/gflags.h>
 
 #include "blaze/CommManager.h"
 #include "blaze/PlatformManager.h"


### PR DESCRIPTION
I updated the pom.xml file to use Spark 2.1.0, and with the newer Spark version the logging class is now org.apache.spark.internal.Logging 

One issue I ran into is a compiler error, thrown because it claims the TestSampler class does not implement the "sample" method, which is required for extending RandomSampler (even though it is implemented). The compiler said the TestSampler class would have to be changed to abstract if it did not implement the "sample" function, but if it's an abstract class then it cannot be instantiated (which it is) but this causes a break in the code. Not sure why the newer version of Spark creates this issue, but I commented out the code that instantiates the TestSampler class to get the code to compile. So I think this needs to be looked into further at some point? 

Thanks,
Brian